### PR TITLE
Send data in chunks similarly to receival.

### DIFF
--- a/include/salticidae/crypto.h
+++ b/include/salticidae/crypto.h
@@ -372,7 +372,7 @@ class TLS {
         else
             SSL_set_connect_state(ssl);
 
-        SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
+        SSL_set_mode(ssl, SSL_MODE_ENABLE_PARTIAL_WRITE);
     }
 
     TLS(const TLS &) = delete;

--- a/include/salticidae/crypto.h
+++ b/include/salticidae/crypto.h
@@ -371,6 +371,8 @@ class TLS {
             SSL_set_accept_state(ssl);
         else
             SSL_set_connect_state(ssl);
+
+        SSL_set_mode(ssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | SSL_MODE_ENABLE_PARTIAL_WRITE);
     }
 
     TLS(const TLS &) = delete;

--- a/src/conn.cpp
+++ b/src/conn.cpp
@@ -162,7 +162,7 @@ void ConnPool::Conn::_send_data_tls(const conn_t &conn, int fd, int events) {
         bytearray_t buff_seg = conn->send_buffer.move_pop();
         ssize_t size = buff_seg.size();
         if (!size) break;
-        ret = tls->send(buff_seg.data(), size);
+        ret = tls->send(buff_seg.data(), std::min(buff_seg.size(), conn->recv_chunk_size));
         SALTICIDAE_LOG_DEBUG("ssl(%d) sent %zd bytes", fd, ret);
         size -= ret;
         if (size > 0)

--- a/src/conn.cpp
+++ b/src/conn.cpp
@@ -162,7 +162,7 @@ void ConnPool::Conn::_send_data_tls(const conn_t &conn, int fd, int events) {
         bytearray_t buff_seg = conn->send_buffer.move_pop();
         ssize_t size = buff_seg.size();
         if (!size) break;
-        ret = tls->send(buff_seg.data(), std::min(buff_seg.size(), conn->recv_chunk_size));
+        ret = tls->send(buff_seg.data(), size);
         SALTICIDAE_LOG_DEBUG("ssl(%d) sent %zd bytes", fd, ret);
         size -= ret;
         if (size > 0)


### PR DESCRIPTION
The SSL connection is not able to send large chunks of data. It will crash with numerous errors which are incredibly hard to hunt down.

This fixes the underlying problem by sending the data in maximum chunks based on the receive chunk size on the other side of the connection.